### PR TITLE
Enhance admin sidebar design

### DIFF
--- a/core/static/core/assets/css/sidebar_admin.css
+++ b/core/static/core/assets/css/sidebar_admin.css
@@ -147,3 +147,37 @@ html, body {
     margin-bottom: 0;
     margin-left: 0;
 }
+
+/* Dark themed sidebar */
+.sidebar-dark {
+    background: linear-gradient(180deg, #343a40, #212529);
+    color: #adb5bd;
+}
+
+.sidebar-dark .accordion-button {
+    background-color: transparent;
+    color: #adb5bd;
+}
+
+.sidebar-dark .accordion-button:not(.collapsed) {
+    color: #fff;
+    background-color: rgba(255, 255, 255, 0.05);
+}
+
+.sidebar-dark .accordion-button::after {
+    filter: invert(80%);
+}
+
+.sidebar-dark .accordion-item {
+    border: none;
+}
+
+.sidebar-dark .list-group-item {
+    background-color: transparent;
+    color: #adb5bd;
+}
+
+.sidebar-dark .list-group-item.active {
+    background-color: rgba(255, 255, 255, 0.1);
+    color: #fff;
+}

--- a/core/templates/core/layout/sidebar_admin.html
+++ b/core/templates/core/layout/sidebar_admin.html
@@ -1,4 +1,4 @@
-<div class="px-2 mt-3">
+<div class="px-2 mt-3 sidebar-dark">
     <div class="accordion accordion-flush custom-accordion" id="accordion-sidebar-admin">
         {% for a in agrupacion_modulos %}
             <div class="accordion-item">


### PR DESCRIPTION
## Summary
- refresh admin sidebar HTML with dark theme wrapper
- add new modern dark style rules for the admin sidebar

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685351c83d88832db25cc87ab4a51a45