### PR TITLE
Remove extraneous line in email notification view

### DIFF
--- a/core/views_admin/notificaciones_correo_view.py
+++ b/core/views_admin/notificaciones_correo_view.py
@@ -146,7 +146,6 @@ class NotificacionesCorreoView(ViewAdministracionBase):
         context['message'] = 'Se enviará un email a todos los usuarios activos'
         context['form'] = CorreoMasivoForm()
         return render(request, 'core/modals/formModal.html', context)
-    0
     def get_notificaciones_correo_template_editar(self, request, context, *args, **kwargs):
         template = CorreoTemplate.objects.get(id=self.data.get('id'))
         context['title'] = 'Editar Template'


### PR DESCRIPTION
## Summary
- fix stray numeric line in `NotificacionesCorreoView`

## Testing
- `python3 -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_685dbdc0125c832dba32bc5ffe80aece